### PR TITLE
Option to Build Only for NiceMC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,7 +76,7 @@ target_compile_options(${PROJECT_NAME} PRIVATE $<$<CONFIG:RelWithDebInfo>:-Wall 
 
 target_link_libraries(${PROJECT_NAME} PUBLIC  RootFftwWrapper::RootFftwWrapper
                                       PRIVATE ZLIB::ZLIB
-                                      PRIVATE ROOT::HistPainter ROOT::Ged ROOT::Physics)
+                                      PUBLIC  ROOT::HistPainter ROOT::Ged ROOT::Physics)
 
 set(DICTNAME G__${PROJECT_NAME})
 root_generate_dictionary(${DICTNAME} ${HEADER_FILES} MODULE ${PROJECT_NAME} LINKDEF LinkDef.h)
@@ -85,7 +85,7 @@ root_generate_dictionary(${DICTNAME} ${HEADER_FILES} MODULE ${PROJECT_NAME} LINK
 #                                       INSTALLING
 #================================================================================================
 
-# Generate AntarcticaRootConfigVersion.cmake
+# Generate AntarcticaRootConfigVersion.cmake in the build/ directory
 include(CMakePackageConfigHelpers)
 write_basic_package_version_file(
   "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
@@ -93,7 +93,7 @@ write_basic_package_version_file(
   COMPATIBILITY AnyNewerVersion
 )
 
-# Install config files
+# Install the config file generated above and the Config file in the cmake/ directory
 include(GNUInstallDirs)
 install(FILES
     "${CMAKE_CURRENT_SOURCE_DIR}/cmake/${PROJECT_NAME}Config.cmake"
@@ -101,11 +101,12 @@ install(FILES
   DESTINATION ${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}
 )
 
-# Install this library and its headers as well as exporting as a CMake Target
+# Install this library and its headers, exporting as a CMake Target that downstream projects can import
 install(
   TARGETS ${PROJECT_NAME} 
   EXPORT ${PROJECT_NAME}Targets 
   FILE_SET HEADERS DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )
 
 # installing CERN ROOT's _rdict.pcm file
@@ -115,6 +116,7 @@ install(
 )
 
 # Generate a Targets.cmake file and directly install it
+# this is so that downstream projects can find the target created by this project.
 install(
   EXPORT ${PROJECT_NAME}Targets
   NAMESPACE AntarcticaRoot::

--- a/cmake/AntarcticaRootConfig.cmake
+++ b/cmake/AntarcticaRootConfig.cmake
@@ -8,7 +8,6 @@ include("${CMAKE_CURRENT_LIST_DIR}/AntarcticaRootTargets.cmake")
 include(CMakeFindDependencyMacro)
 find_dependency(RootFftwWrapper REQUIRED)
 
-# I guess it doesn't hurt to add checks here for stuff that doesn't propagate
 find_dependency(ZLIB REQUIRED) # TODO: figure out if zlib is required
 find_dependency(ROOT CONFIG REQUIRED COMPONENTS HistPainter Physics Ged)
 


### PR DESCRIPTION
Adds an option to only compile the files needed by NiceMC.

This PR also fixes a bug (sort of):
- `ROOT::<library>` should be linked `PUBLIC`ly if the ROOT libraries appear in the public API of AntarcticaRoot, otherwise downstream projects would have to link manually themselves.
- In the [previous PR](https://github.com/PUEOCollaboration/libAntarcticaRoot/pull/2) I had all `ROOT::<library>` linked `PRIVATE`ly which somehow did not cause a problem.
- I don't know enough about `AntarcticaRoot` to decide which libraries are used only internally and which are public, so   everything is public. Sorry

- Independent but related PR in [NiceMC](https://github.com/PUEOCollaboration/nicemc/pull/64)